### PR TITLE
new: basic jwt auth was implemented with _simple_jwt lib

### DIFF
--- a/src/apps/blog/serializers.py
+++ b/src/apps/blog/serializers.py
@@ -13,6 +13,7 @@ class PostSerializer(serializers.ModelSerializer):
         fields = ['id', 'author', 'title', 'text', 'category']
 
 
+
 class CategorySerializer(serializers.ModelSerializer):
     
     class Meta:

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -68,9 +68,14 @@ CORS_ORIGIN_WHITELIST = [
 ]
 
 REST_FRAMEWORK = {
-  'DEFAULT_PERMISSION_CLASSES': [
-      'rest_framework.permissions.AllowAny', 
-  ]
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.BasicAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+    ],
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.AllowAny', 
+    ],
 }
 
 ROOT_URLCONF = 'config.urls'

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -17,6 +17,10 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include, path
 
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+)
 
 from api.v1.urls import router
 
@@ -27,4 +31,7 @@ urlpatterns = [
     path('api/v1/', include(router.urls)),
     
     path('api-auth/', include('rest_framework.urls')),
+    path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+
 ]


### PR DESCRIPTION
restframework_simple_jwt is added an its working

TO DO: implement auto populating headers with field "Authorization: Bearer ...." so requests could pass through Default Auth Class. For now Basic and Sessions ones are left